### PR TITLE
Do not emit errors for lines with only spaces

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ define(function (require) {
      * @return {object} - Linting results.
      */
     function lintFile(text, path) {
+        text = text.replace(/^[ \t]+$/gm, "");
 
         var options = preferences.get('options'),
             errorIndex,


### PR DESCRIPTION
Use code from https://github.com/adobe/brackets/blob/master/src/extensions/default/JSLint/main.js#L75. Using @TomMalbran's suggestion in adobe/brackets#8842.
