### PR TITLE
Optionally skip linting whitespace-only lines.

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ define(function (require) {
      * @return {object} - Linting results.
      */
     function lintFile(text, path) {
-        if (!preferences.get('skipBlankLines')) {
+        if (preferences.get('skipBlankLines')) {
             text = text.replace(/^[ \t]+$/gm, '');
         }
 

--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ define(function (require) {
             CodeInspection.requestRun(JSLINT_NAME);
         });
 
-    preferences.definePreference('lintWSLines', 'boolean', true)
+    preferences.definePreference('skipBlankLines', 'boolean', false)
         .on('change', function () {
             CodeInspection.requestRun(JSLINT_NAME);
         });
@@ -75,8 +75,8 @@ define(function (require) {
      * @return {object} - Linting results.
      */
     function lintFile(text, path) {
-        if (!preferences.get('lintWSLines')) {
-            text = text.replace(/^[ \t]+$/gm, "");
+        if (!preferences.get('skipBlankLines')) {
+            text = text.replace(/^[ \t]+$/gm, '');
         }
 
         var options = preferences.get('options'),

--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ define(function (require) {
      * @return {object} - Linting results.
      */
     function lintFile(text, path) {
+        text = text.replace(/^[ \t]+$/gm, "");
 
         var options = preferences.get('options'),
             errorIndex,

--- a/main.js
+++ b/main.js
@@ -50,6 +50,11 @@ define(function (require) {
             CodeInspection.requestRun(JSLINT_NAME);
         });
 
+    preferences.definePreference('lintWSLines', 'boolean', true)
+        .on('change', function () {
+            CodeInspection.requestRun(JSLINT_NAME);
+        });
+
     /**
      * Retrieves the number of spaces used by the editor as an indent for a given path, regardless of
      * whether TAB or SPACE characters are used.
@@ -70,7 +75,9 @@ define(function (require) {
      * @return {object} - Linting results.
      */
     function lintFile(text, path) {
-        text = text.replace(/^[ \t]+$/gm, "");
+        if (!preferences.get('lintWSLines')) {
+            text = text.replace(/^[ \t]+$/gm, "");
+        }
 
         var options = preferences.get('options'),
             errorIndex,


### PR DESCRIPTION
Follow up on #1, have not tested this.

Does `lintWSLines` sound like a good option name?

Should the relinting happen on change of this option (I copied the code from the main options to this, since it seems like that makes sense.).
